### PR TITLE
Add NixOS flake with package and service module

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ README.md                       ← You are here
 AGENTS.md                       Agent-specific development guide
 UPSTREAM-MERGE-GUIDE.md         Structural divergences from upstream + merge strategy
 
+nix/
+├── package.nix                 Nix package derivation (buildGoModule + asset bundling)
+└── module.nix                  NixOS service module (services.aroz)
+
 docs/
 ├── quickstart.md               Build, run, first user, Docker
 ├── architecture.md             Request routing, filesystem layers, AGI model, internals
@@ -37,7 +41,8 @@ docs/
 │   └── storage-and-sharing.md  Storage pools, file sharing, network file servers
 ├── admins/
 │   ├── configuration.md        Startup flags, storage pools, vendor customization
-│   └── deployment.md           Install guides (Linux, Windows, Docker, systemd)
+│   ├── deployment.md           Install guides (Linux, Windows, Docker, systemd)
+│   └── nixos.md                Nix flake, NixOS module, packaging gotchas
 └── developers/
     ├── apps-and-subservices.md  Webapp + subservice development guide
     ├── agi-reference.md        Complete AGI server-side scripting API
@@ -72,6 +77,7 @@ Dockerfile                      Multi-stage Docker build
 | [Frontend API](docs/developers/frontend-api.md) | App developers | ao_module.js: windows, files, uploads, utilities |
 | [Configuration](docs/admins/configuration.md) | Admins/deployers | Startup flags, storage pools, vendor customization |
 | [Deployment](docs/admins/deployment.md) | Admins/deployers | Linux, Windows, Docker, systemd |
+| [NixOS](docs/admins/nixos.md) | Admins/deployers | Nix flake, NixOS module, packaging gotchas |
 | [Architecture](docs/architecture.md) | Contributors | Request routing, filesystem layers, AGI execution model |
 | [AGENTS.md](AGENTS.md) | AI agents | Testing strategies, process management, gotchas |
 | [Upstream Merge Guide](UPSTREAM-MERGE-GUIDE.md) | Maintainers | Structural divergences, conflict resolution |
@@ -81,6 +87,7 @@ Dockerfile                      Multi-stage Docker build
 - **Terminal subservice** — web-based shell via ttyd, accessible from the ArozOS desktop
   - **Mobile touch toolbar** — Tab, Ctrl-C, Esc, arrows, tmux macros, and more for phone use
 - **Docker support** — multi-stage Dockerfile with ttyd included
+- **NixOS flake** — `buildGoModule` package + NixOS service module with declarative configuration
 - **Developer documentation** — consolidated from scattered upstream sources into structured docs
 
 ## Screenshots

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Image](img/banner.png?raw=true)
 
-# monika-aroz
+# aroz
 
 Fork of [ArozOS](https://github.com/tobychui/arozos) — a web-based desktop operating system written in Go.
 

--- a/UPSTREAM-MERGE-GUIDE.md
+++ b/UPSTREAM-MERGE-GUIDE.md
@@ -5,7 +5,7 @@ This fork diverges structurally from [upstream ArozOS](https://github.com/tobych
 ## Remotes
 
 ```
-origin    git@github.com:neonspectra/monika-aroz.git   (our fork)
+origin    git@github.com:spectrasecure/aroz.git      (our fork)
 upstream  https://github.com/tobychui/arozos            (tobychui's repo)
 ```
 

--- a/docs/admins/nixos.md
+++ b/docs/admins/nixos.md
@@ -1,0 +1,471 @@
+# NixOS Packaging and Deployment
+
+This document covers the Nix flake, package derivation, NixOS service module, and
+deployment patterns for running Aroz on NixOS. It is written to be sufficient for
+working on the packaging from cold — no prior context required.
+
+## Architecture Decision: Native NixOS vs. Container
+
+Aroz runs as a native NixOS service, not inside a Docker container. This is a deliberate
+choice driven by the long-term direction of this fork.
+
+The goal is a browser-based desktop environment where NixOS handles system-level concerns
+(package management, service lifecycle, storage, users) and Aroz owns the interactive
+desktop layer (windowing, file management UI, webapps, terminal). Containerizing Aroz
+would create an isolation boundary between the desktop and the system it's meant to
+manage — defeating the point. The native approach lets Aroz's subservices (like the
+terminal) operate directly on the host, and lets NixOS manage the binary, assets, and
+service lifecycle declaratively.
+
+The tradeoff is that NixOS's filesystem conventions (no `/bin/bash`, read-only Nix store,
+no FHS) require patching at the packaging layer. The package and module handle this
+transparently.
+
+## Flake Structure
+
+```
+flake.nix           Flake definition — package, module, overlay
+flake.lock          Pinned nixpkgs (nixos-25.11)
+nix/
+├── package.nix     buildGoModule derivation
+└── module.nix      NixOS service module (services.aroz)
+```
+
+The flake exports:
+
+| Output | Description |
+|--------|-------------|
+| `packages.${system}.default` | The Aroz package (binary + assets) |
+| `packages.${system}.aroz` | Same, named explicitly |
+| `nixosModules.default` | NixOS service module |
+| `nixosModules.aroz` | Same, named explicitly |
+| `overlays.default` | Overlay that adds `pkgs.aroz` |
+
+## Package (`nix/package.nix`)
+
+The package uses `buildGoModule` against the `src/` directory. Key details:
+
+- **Go module path**: `imuslab.com/arozos` (upstream's, unchanged)
+- **Binary name**: `arozos` (matches upstream expectations; the Nix *package* is named `aroz`)
+- **vendorHash**: Nix fetches Go dependencies independently — the upstream `vendor/`
+  directory is ignored because its `modules.txt` is stale
+- **Build tags**: `netgo` (pure Go networking)
+- **ldflags**: `-s -w` (strip debug info)
+
+### What the package contains
+
+```
+$out/
+├── bin/arozos                    Wrapper script (sets PATH, execs binary)
+└── share/aroz/
+    ├── web/                      Static webapps (immutable)
+    ├── system/                   Config templates, HTML templates, geoip data
+    └── subservice/               Subservice definitions (Terminal/start.sh, etc.)
+```
+
+### Runtime dependencies via wrapper
+
+The binary is wrapped with `makeWrapper` to prepend `ffmpeg` and `ttyd` to `PATH`.
+ArozOS discovers these at runtime via `exec.LookPath` / `which`. Without the wrapper,
+ArozOS would report ffmpeg as missing and the terminal subservice wouldn't find ttyd.
+
+The wrapper script (`$out/bin/arozos`) sets up PATH and then `exec`s the real binary
+at `$out/bin/.arozos-wrapped`.
+
+### Updating the vendorHash
+
+When Go dependencies change (new modules, version bumps in `go.mod`):
+
+1. Set `vendorHash` to a dummy value: `sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=`
+2. Run `nix build` — it will fail with `got: sha256-...`
+3. Replace the dummy with the real hash
+
+## NixOS Module (`nix/module.nix`)
+
+### Quick start
+
+Add the flake input and import the module:
+
+```nix
+# flake.nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    aroz.url = "github:spectrasecure/aroz";
+    aroz.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { nixpkgs, aroz, ... }: {
+    nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        aroz.nixosModules.default
+        ./configuration.nix
+      ];
+    };
+  };
+}
+```
+
+Then in your NixOS configuration:
+
+```nix
+# configuration.nix
+{
+  services.aroz = {
+    enable = true;
+    port = 8090;
+    hostname = "My Desktop";
+    openFirewall = true;
+  };
+}
+```
+
+### Using with an existing user
+
+By default, the module creates a system user `aroz`. To run under an existing user:
+
+```nix
+{
+  services.aroz = {
+    enable = true;
+    port = 8090;
+    user = "myuser";
+    group = "users";
+    dataDir = "/persist/aroz";   # impermanence-friendly path
+  };
+}
+```
+
+The module only creates the user/group when they're set to the default `"aroz"`. When
+overridden, you're responsible for ensuring the user exists.
+
+### With Tailscale Serve (HTTPS)
+
+```nix
+{
+  services.tailscale.enable = true;
+  services.tailscale.permitCertUid = "myuser";  # allow cert provisioning
+
+  services.aroz = {
+    enable = true;
+    port = 8090;
+    user = "myuser";
+    group = "users";
+  };
+}
+```
+
+Then after deployment:
+
+```bash
+sudo tailscale serve --bg http://localhost:8090
+```
+
+The service is now available at `https://<hostname>.<tailnet>.ts.net/` with automatic
+TLS certificate provisioning. No Caddy, no ACME config, no cert rotation.
+
+### With built-in TLS
+
+```nix
+{
+  services.aroz = {
+    enable = true;
+    port = 8090;
+    tls = {
+      enable = true;
+      port = 8443;
+      certFile = "/path/to/cert.pem";
+      keyFile = "/path/to/key.pem";
+      disableHttp = false;  # set true for HTTPS-only
+    };
+  };
+}
+```
+
+### Module options reference
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enable` | bool | `false` | Enable the Aroz service |
+| `package` | package | `pkgs.aroz` | The Aroz package to use |
+| `port` | port | `8080` | HTTP listening port |
+| `hostname` | string | `"Aroz"` | Display name shown in the UI |
+| `dataDir` | path | `"/var/lib/aroz"` | Working directory for all mutable state |
+| `user` | string | `"aroz"` | User to run the service as |
+| `group` | string | `"aroz"` | Group to run the service as |
+| `maxUploadSize` | int | `8192` | Maximum upload size in MB |
+| `openFirewall` | bool | `false` | Open the HTTP (and TLS) port in the firewall |
+| `extraFlags` | list of string | `[]` | Additional CLI flags passed to `arozos` |
+| `tls.enable` | bool | `false` | Enable built-in TLS |
+| `tls.port` | port | `8443` | HTTPS listening port |
+| `tls.certFile` | path | — | TLS certificate path (required if tls.enable) |
+| `tls.keyFile` | path | — | TLS key path (required if tls.enable) |
+| `tls.disableHttp` | bool | `false` | Disable HTTP entirely (HTTPS only) |
+
+### What the module disables by default
+
+The module passes these flags to ArozOS, disabling sysadmin features that conflict with
+or duplicate NixOS's role:
+
+| Flag | Why disabled |
+|------|-------------|
+| `-allow_pkg_install=false` | NixOS manages packages declaratively |
+| `-enable_hwman=false` | Hardware management belongs to NixOS |
+| `-enable_pwman=false` | Power management belongs to NixOS/systemd |
+| `-allow_mdns=false` | Not needed for Tailscale-based access |
+| `-allow_ssdp=false` | Windows network discovery, not relevant |
+| `-allow_upnp=false` | UPnP port forwarding, not relevant |
+| `-disable_ip_resolver=true` | Avoids unnecessary external lookups |
+
+To re-enable any of these, use `extraFlags`:
+
+```nix
+services.aroz.extraFlags = [ "-allow_mdns=true" "-allow_cluster=true" ];
+```
+
+See [configuration.md](configuration.md) for the full flag reference.
+
+## Asset Management: Immutable vs. Mutable
+
+ArozOS expects three asset directories in its working directory. They have different
+mutability requirements:
+
+### `web/` — Immutable (symlinked from Nix store)
+
+Static webapps: HTML, JS, CSS, icons, AGI scripts. ArozOS reads but never writes to
+this directory. The module symlinks it directly from the Nix store:
+
+```
+{dataDir}/web → /nix/store/{hash}-aroz-{version}/share/aroz/web
+```
+
+This symlink updates automatically on package upgrades.
+
+### `subservice/` — Mutable copy (patched)
+
+Subservice definitions including `start.sh` launcher scripts. Must be a mutable copy
+rather than a Nix store symlink for two reasons:
+
+1. **Shebang patching**: Scripts ship with `#!/bin/bash`, which doesn't exist on NixOS.
+   The activation script patches line 1 to `#!/usr/bin/env bash` and any other
+   `/bin/bash` references (e.g., the argument to `ttyd`) to the Nix store bash path.
+
+2. **Runtime state**: ArozOS may need to write to this directory for subservice
+   management.
+
+The directory is re-copied and re-patched on package version changes.
+
+### `system/` — Mutable copy (seeded once)
+
+A mix of static templates and runtime state:
+
+**Templates and static assets** (shipped with the package, never modified at runtime):
+- `system/agi/error.html` — AGI error page
+- `system/auth/register.html`, `regsetting.html` — registration UI
+- `system/errors/*.html` — HTTP error pages
+- `system/ldap/newPasswordTemplate.html` — LDAP password reset
+- `system/newitem/*` — "New File" templates
+- `system/reset/*.html` — password reset email templates
+- `system/share/*.html` — file sharing pages and assets
+- `system/www/*.html` — webroot fallback pages
+- `system/geoip.json` — IP geolocation data
+- `system/time/wintz.json` — Windows timezone mapping
+- `system/ssdp.xml`, `ssdp_printer.xml` — SSDP descriptors
+- `system/update.json` — version metadata
+- `system/disk/smart/*`, `system/hardware/*` — platform-specific binaries (unused on NixOS)
+
+**Runtime state** (created by ArozOS during operation):
+- `system/ao.db` — main application database (Bolt)
+- `system/auth/authlog.db` — authentication log database
+- `system/bridge.json` — network bridge configuration
+- `system/cron.json` — scheduled task definitions
+- `system/smtp_conf.json` — SMTP settings (if configured)
+- `system/logs/system/system_*.log` — system logs (monthly rotation)
+- `system/logs/subservice/subserv_*.log` — subservice logs (monthly rotation)
+
+The module seeds `system/` on first run by copying from the Nix store. On upgrades, new
+files are copied without overwriting existing ones (`cp -rn`), preserving databases and
+configuration that ArozOS has written. A version marker at `{dataDir}/.aroz-pkg-version`
+tracks whether the seeded version matches the current package.
+
+### Filesystem layout at runtime
+
+After deployment, the data directory looks like:
+
+```
+{dataDir}/
+├── .aroz-pkg-version          Version marker (triggers re-seed on upgrade)
+├── web -> /nix/store/…        Symlink to immutable webapps
+├── subservice/                Mutable copy (patched shebangs)
+│   └── Terminal/
+│       ├── start.sh           #!/usr/bin/env bash, ttyd path patched
+│       └── moduleInfo.json
+├── system/                    Mutable copy (seeded, then owned by ArozOS)
+│   ├── ao.db                  Main database (created at runtime)
+│   ├── auth/                  Auth DB + registration templates
+│   ├── logs/                  Monthly log files
+│   └── …                     Templates, config, static data
+├── files/                     User file storage
+│   └── users/{username}/      Per-user sandboxed directories
+└── tmp/                       Temporary upload/processing storage
+    ├── users/
+    └── webdav/
+```
+
+## Systemd Service Details
+
+The service unit includes several NixOS-specific configurations worth understanding:
+
+### Process group management
+
+```nix
+KillMode = "control-group";
+```
+
+ArozOS spawns subservice child processes (notably ttyd for the terminal). Without
+`control-group` kill mode, stopping the service would orphan these children, holding
+ports and potentially conflicting on restart.
+
+### System PATH
+
+```nix
+path = with pkgs; [ bash coreutils which ];
+```
+
+Systemd services on NixOS get a minimal PATH (coreutils, findutils, gnugrep, gnused,
+systemd). ArozOS shells out to utilities not in this default set:
+- `which` — used by `apt.PackageExists()` to detect installed tools
+- `bash` — spawned by subservice scripts
+- `coreutils` — `du` for disk usage calculations
+
+Without these in the service PATH, ffmpeg detection fails (even though the wrapper puts
+ffmpeg in PATH, ArozOS can't find `which` to check for it) and subservices can't launch.
+
+### Filesystem hardening
+
+```nix
+ProtectSystem = "strict";
+ReadWritePaths = [ cfg.dataDir ];
+```
+
+The service can only write to its data directory. The rest of the filesystem (including
+`/nix/store`) is read-only. This is why subservice scripts must be copied out of the
+store rather than symlinked — they need to be in a writable path.
+
+### No PrivateTmp
+
+```nix
+PrivateTmp = false;
+```
+
+ArozOS manages its own temporary storage via the `-tmp` flag, creating `{dataDir}/tmp/`.
+Systemd's `PrivateTmp` would create an isolated `/tmp` that ArozOS doesn't use, while
+potentially interfering with its own temp management.
+
+## Gotchas and Troubleshooting
+
+### NixOS has no `/bin/bash`
+
+The most pervasive issue. It manifests in two ways:
+
+1. **Shebangs in shell scripts**: Any `#!/bin/bash` script fails with
+   `No such file or directory`. The activation script patches these to
+   `#!/usr/bin/env bash`.
+
+2. **Hardcoded `/bin/bash` as a command argument**: The terminal subservice runs
+   `ttyd ... /bin/bash`, which also fails with `No such file or directory` even though
+   the error looks like it's about ttyd. The activation script patches these to the
+   Nix store bash path.
+
+If you add new subservices with shell scripts, they'll need the same treatment. The
+activation script handles `*.sh` files in `{dataDir}/subservice/` automatically.
+
+### vendorHash vs. vendor directory
+
+ArozOS upstream ships a `vendor/` directory, but its `modules.txt` is often stale
+relative to `go.mod`. Nix's `buildGoModule` validates vendor consistency strictly. The
+fix: set a real `vendorHash` so Nix fetches dependencies itself, ignoring the shipped
+vendor directory entirely. See "Updating the vendorHash" above.
+
+### Activation script ordering
+
+The activation script that creates symlinks and seeds directories depends on
+`[ "specialfs" "users" ]`. On a completely fresh system (first boot after
+`nixos-install`), the data directory might not exist yet. The script handles this
+by running `mkdir -p` before attempting symlinks, rather than relying on
+`systemd.tmpfiles.rules` having already executed.
+
+### The version marker race
+
+The activation script uses `{dataDir}/.aroz-pkg-version` to decide whether to re-copy
+`subservice/` and re-seed `system/`. If you manually write this file (or if the package
+version string doesn't change between builds), the script will skip the update. To force
+a re-copy:
+
+```bash
+rm {dataDir}/.aroz-pkg-version
+sudo nixos-rebuild switch --flake .#myhost
+# or: sudo /nix/store/{current-system}/activate
+```
+
+### ffmpeg detection
+
+ArozOS checks for ffmpeg by running `which ffmpeg` via Go's `exec.Command`. This
+requires both:
+- `ffmpeg` in PATH (provided by the `makeWrapper` in the package)
+- `which` in PATH (provided by the service module's `path` option)
+
+If you see `[AGI] ffmpeg not installed on host OS` in the journal, one of these is
+missing.
+
+### Subservice port allocation
+
+ArozOS assigns subservice ports incrementally starting from 12810. The terminal gets
+12810, additional subservices get 12811, 12812, etc. If orphaned subservice processes
+hold these ports (e.g., after a `kill -9` of the main process without `KillMode =
+"control-group"`), ArozOS will fail to start subservices on restart.
+
+Check with: `lsof -i :12810`
+
+The `control-group` kill mode in the service unit should prevent this, but if it happens:
+```bash
+sudo systemctl stop aroz
+pkill -9 -f "ttyd.*12810"
+sudo systemctl start aroz
+```
+
+### ArozOS user filesystem is sandboxed
+
+ArozOS virtualizes its filesystem. The "User" folder in the UI maps to
+`{dataDir}/files/users/{username}/`, not to the system root or the user's home
+directory. This is by design — ArozOS is a multi-user web desktop with per-user
+storage isolation.
+
+## Building the package locally
+
+```bash
+# From the repo root:
+nix build .#default
+
+# Inspect the output:
+ls result/bin/           # arozos wrapper + .arozos-wrapped
+ls result/share/aroz/    # web/, system/, subservice/
+
+# Test it runs:
+result/bin/arozos -version
+```
+
+## Reference deployment
+
+The [shadowsea](https://github.com/tymasconfederation/shadowsea) repository contains
+a production deployment of this package on NixOS with EYD (erase-your-darlings)
+impermanence. The relevant files:
+
+- `flake.nix` — aroz flake input with `nixpkgs.follows`
+- `nixos/stanza.nix` — host config with `services.aroz` block
+- `nixos/STANZA.md` — host-specific operational notes
+
+That deployment uses `dataDir = "/persist/aroz"` (durable across reboots on an
+impermanence system), runs under an existing `monika` user, and serves over HTTPS via
+Tailscale Serve.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,8 +9,8 @@
 ## Build and Run
 
 ```bash
-git clone git@github.com:neonspectra/monika-aroz.git
-cd monika-aroz
+git clone git@github.com:spectrasecure/aroz.git
+cd aroz
 
 # Build the binary
 cd src && go build -o ../arozos && cd ..

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775002709,
+        "narHash": "sha256-d3Yx83vSrN+2z/loBh4mJpyRqr9aAJqlke4TkpFmRJA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "Aroz — web desktop environment (ArozOS fork)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+  };
+
+  outputs = { self, nixpkgs }:
+  let
+    systems = [ "x86_64-linux" "aarch64-linux" ];
+    forAllSystems = f: nixpkgs.lib.genAttrs systems (system:
+      f nixpkgs.legacyPackages.${system}
+    );
+  in {
+    packages = forAllSystems (pkgs: {
+      default = pkgs.callPackage ./nix/package.nix {};
+      aroz = pkgs.callPackage ./nix/package.nix {};
+    });
+
+    nixosModules.default = import ./nix/module.nix;
+    nixosModules.aroz = import ./nix/module.nix;
+
+    overlays.default = final: prev: {
+      aroz = final.callPackage ./nix/package.nix {};
+    };
+  };
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,227 @@
+# Aroz NixOS service module
+#
+# Configures ArozOS as a systemd service with:
+# - Immutable assets symlinked from the Nix store (web/, subservice/)
+# - Mutable state directory with version-gated seeding (system/)
+# - Sysadmin features disabled by default (hardware mgmt, discovery, pkg install)
+# - Process group management for subservice children (ttyd)
+#
+# Usage in a NixOS configuration:
+#   services.aroz = {
+#     enable = true;
+#     port = 8090;
+#     dataDir = "/persist/aroz";
+#   };
+
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.aroz;
+
+  # Build the flag string from module options.
+  # Sysadmin features are disabled by default — this is a web desktop,
+  # not a system management tool. NixOS handles that layer.
+  flagList = [
+    "-port ${toString cfg.port}"
+    "-hostname \"${cfg.hostname}\""
+    "-root \"${cfg.dataDir}/files/\""
+    "-tmp \"${cfg.dataDir}/\""
+    "-max_upload_size ${toString cfg.maxUploadSize}"
+    # Disable sysadmin features by default
+    "-allow_pkg_install=false"
+    "-enable_hwman=false"
+    "-enable_pwman=false"
+    "-allow_mdns=false"
+    "-allow_ssdp=false"
+    "-allow_upnp=false"
+    "-disable_ip_resolver=true"
+  ] ++ lib.optionals cfg.tls.enable [
+    "-tls=true"
+    "-tls_port ${toString cfg.tls.port}"
+    "-cert \"${cfg.tls.certFile}\""
+    "-key \"${cfg.tls.keyFile}\""
+  ] ++ lib.optionals cfg.tls.disableHttp [
+    "-disable_http=true"
+  ] ++ cfg.extraFlags;
+
+  flagString = lib.concatStringsSep " " flagList;
+
+  # The package provides the binary and the static assets.
+  pkg = cfg.package;
+in
+{
+  options.services.aroz = {
+    enable = lib.mkEnableOption "Aroz web desktop";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.aroz or (pkgs.callPackage ../nix/package.nix {});
+      defaultText = lib.literalExpression "pkgs.aroz";
+      description = "The Aroz package to use.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 8080;
+      description = "HTTP listening port.";
+    };
+
+    hostname = lib.mkOption {
+      type = lib.types.str;
+      default = "Aroz";
+      description = "Display name for this host.";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/aroz";
+      description = ''
+        Working directory for Aroz. Contains mutable state (databases, logs,
+        user files) and symlinks to immutable assets in the Nix store.
+        On impermanence hosts, set this to a path under /persist.
+      '';
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "aroz";
+      description = "User account to run Aroz under.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "aroz";
+      description = "Group to run Aroz under.";
+    };
+
+    tls = {
+      enable = lib.mkEnableOption "TLS for Aroz";
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 8443;
+        description = "HTTPS listening port.";
+      };
+
+      certFile = lib.mkOption {
+        type = lib.types.path;
+        description = "Path to TLS certificate.";
+      };
+
+      keyFile = lib.mkOption {
+        type = lib.types.path;
+        description = "Path to TLS private key.";
+      };
+
+      disableHttp = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Disable HTTP entirely (HTTPS only). Requires tls.enable.";
+      };
+    };
+
+    maxUploadSize = lib.mkOption {
+      type = lib.types.int;
+      default = 8192;
+      description = "Maximum upload size in MB.";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Open the configured port(s) in the firewall.";
+    };
+
+    extraFlags = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      description = ''
+        Additional CLI flags passed to arozos.
+        See docs/admins/configuration.md for the full list.
+      '';
+      example = [ "-console" "-public_reg=true" ];
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Create system user/group if using the defaults.
+    # When user/group are overridden (e.g. to "monika"), the caller is
+    # responsible for ensuring they exist.
+    users.users.${cfg.user} = lib.mkIf (cfg.user == "aroz") {
+      isSystemUser = true;
+      group = cfg.group;
+      home = cfg.dataDir;
+      description = "Aroz service user";
+    };
+
+    users.groups.${cfg.group} = lib.mkIf (cfg.group == "aroz") {};
+
+    # Create the data directory structure.
+    systemd.tmpfiles.rules = [
+      "d ${cfg.dataDir}          0755 ${cfg.user} ${cfg.group} -"
+      "d ${cfg.dataDir}/files    0755 ${cfg.user} ${cfg.group} -"
+      "d ${cfg.dataDir}/tmp      0755 ${cfg.user} ${cfg.group} -"
+    ];
+
+    # Activation script: symlink immutable assets, seed mutable system/ dir.
+    system.activationScripts.aroz-assets = {
+      text = ''
+        # Symlink immutable assets — always points to current package version.
+        ln -sfn "${pkg}/share/aroz/web" "${cfg.dataDir}/web"
+        ln -sfn "${pkg}/share/aroz/subservice" "${cfg.dataDir}/subservice"
+
+        # Seed system/ on first run. On upgrades, copy new files without
+        # overwriting existing state (databases, logs, configs).
+        MARKER="${cfg.dataDir}/.aroz-pkg-version"
+        CURRENT_VERSION="${pkg.version}"
+
+        if [ ! -d "${cfg.dataDir}/system" ]; then
+          # First run: copy everything
+          cp -r "${pkg}/share/aroz/system" "${cfg.dataDir}/system"
+          chown -R ${cfg.user}:${cfg.group} "${cfg.dataDir}/system"
+          echo "$CURRENT_VERSION" > "$MARKER"
+        elif [ ! -f "$MARKER" ] || [ "$(cat "$MARKER")" != "$CURRENT_VERSION" ]; then
+          # Upgrade: copy new files only (no-clobber)
+          cp -rn "${pkg}/share/aroz/system/." "${cfg.dataDir}/system/"
+          chown -R ${cfg.user}:${cfg.group} "${cfg.dataDir}/system"
+          echo "$CURRENT_VERSION" > "$MARKER"
+        fi
+      '';
+      deps = [ "specialfs" "users" ];
+    };
+
+    # Systemd service.
+    systemd.services.aroz = {
+      description = "Aroz Web Desktop";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        WorkingDirectory = cfg.dataDir;
+        ExecStart = "${pkg}/bin/arozos ${flagString}";
+
+        # Kill the entire cgroup on stop — this catches subservice children
+        # (ttyd, etc.) that ArozOS spawns via exec.Command.
+        KillMode = "control-group";
+        TimeoutStopSec = "10s";
+
+        Restart = "on-failure";
+        RestartSec = "10s";
+
+        # Hardening
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ReadWritePaths = [ cfg.dataDir ];
+        PrivateTmp = false; # ArozOS manages its own tmp via -tmp flag
+      };
+    };
+
+    # Firewall
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall (
+      [ cfg.port ] ++ lib.optionals cfg.tls.enable [ cfg.tls.port ]
+    );
+  };
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -188,9 +188,14 @@ in
           rm -rf "${cfg.dataDir}/subservice"
           cp -r "${pkg}/share/aroz/subservice" "${cfg.dataDir}/subservice"
           chmod -R u+w "${cfg.dataDir}/subservice"
-          # Patch shebangs: NixOS has no /bin/bash.
+          # Patch /bin/bash references: NixOS has no /bin/bash.
+          # Shebangs become #!/usr/bin/env bash (portable).
+          # Bare /bin/bash references (e.g. ttyd arguments) become the Nix bash path.
           find "${cfg.dataDir}/subservice" -name '*.sh' -exec \
-            ${pkgs.gnused}/bin/sed -i 's|#!/bin/bash|#!/usr/bin/env bash|g' {} +
+            ${pkgs.gnused}/bin/sed -i \
+              -e '1s|^#!/bin/bash|#!/usr/bin/env bash|' \
+              -e '2,$s|/bin/bash|${pkgs.bash}/bin/bash|g' \
+              {} +
           chown -R ${cfg.user}:${cfg.group} "${cfg.dataDir}/subservice"
         fi
 

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,8 +1,9 @@
 # Aroz NixOS service module
 #
 # Configures ArozOS as a systemd service with:
-# - Immutable assets symlinked from the Nix store (web/, subservice/)
-# - Mutable state directory with version-gated seeding (system/)
+# - Immutable web assets symlinked from the Nix store
+# - Mutable copies of subservice/ and system/ with shebang patching
+#   (NixOS has no /bin/bash; scripts get #!/usr/bin/env bash)
 # - Sysadmin features disabled by default (hardware mgmt, discovery, pkg install)
 # - Process group management for subservice children (ttyd)
 #
@@ -163,27 +164,47 @@ in
       "d ${cfg.dataDir}/tmp      0755 ${cfg.user} ${cfg.group} -"
     ];
 
-    # Activation script: symlink immutable assets, seed mutable system/ dir.
+    # Activation script: symlink immutable assets, seed mutable dirs.
     system.activationScripts.aroz-assets = {
       text = ''
-        # Symlink immutable assets — always points to current package version.
-        ln -sfn "${pkg}/share/aroz/web" "${cfg.dataDir}/web"
-        ln -sfn "${pkg}/share/aroz/subservice" "${cfg.dataDir}/subservice"
+        # Ensure data dir exists (tmpfiles may not have run yet on first activation).
+        mkdir -p "${cfg.dataDir}/files" "${cfg.dataDir}/tmp"
 
-        # Seed system/ on first run. On upgrades, copy new files without
-        # overwriting existing state (databases, logs, configs).
+        # Symlink immutable web assets — always points to current package version.
+        ln -sfn "${pkg}/share/aroz/web" "${cfg.dataDir}/web"
+
         MARKER="${cfg.dataDir}/.aroz-pkg-version"
         CURRENT_VERSION="${pkg.version}"
 
+        NEEDS_UPDATE=false
+        if [ ! -f "$MARKER" ] || [ "$(cat "$MARKER")" != "$CURRENT_VERSION" ]; then
+          NEEDS_UPDATE=true
+        fi
+
+        # Subservice: mutable copy (not symlink) because NixOS lacks /bin/bash
+        # and start.sh scripts need shebang patching + the directory must be
+        # writable for ArozOS to manage subservice state.
+        if [ ! -d "${cfg.dataDir}/subservice" ] || [ "$NEEDS_UPDATE" = true ]; then
+          rm -rf "${cfg.dataDir}/subservice"
+          cp -r "${pkg}/share/aroz/subservice" "${cfg.dataDir}/subservice"
+          chmod -R u+w "${cfg.dataDir}/subservice"
+          # Patch shebangs: NixOS has no /bin/bash.
+          find "${cfg.dataDir}/subservice" -name '*.sh' -exec \
+            ${pkgs.gnused}/bin/sed -i 's|#!/bin/bash|#!/usr/bin/env bash|g' {} +
+          chown -R ${cfg.user}:${cfg.group} "${cfg.dataDir}/subservice"
+        fi
+
+        # Seed system/ on first run. On upgrades, copy new files without
+        # overwriting existing state (databases, logs, configs).
         if [ ! -d "${cfg.dataDir}/system" ]; then
-          # First run: copy everything
           cp -r "${pkg}/share/aroz/system" "${cfg.dataDir}/system"
           chown -R ${cfg.user}:${cfg.group} "${cfg.dataDir}/system"
-          echo "$CURRENT_VERSION" > "$MARKER"
-        elif [ ! -f "$MARKER" ] || [ "$(cat "$MARKER")" != "$CURRENT_VERSION" ]; then
-          # Upgrade: copy new files only (no-clobber)
+        elif [ "$NEEDS_UPDATE" = true ]; then
           cp -rn "${pkg}/share/aroz/system/." "${cfg.dataDir}/system/"
           chown -R ${cfg.user}:${cfg.group} "${cfg.dataDir}/system"
+        fi
+
+        if [ "$NEEDS_UPDATE" = true ]; then
           echo "$CURRENT_VERSION" > "$MARKER"
         fi
       '';
@@ -195,6 +216,10 @@ in
       description = "Aroz Web Desktop";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
+
+      # Ensure the system PATH is available so ArozOS can find utilities
+      # like `which`, `bash`, `du`, etc. that it shells out to.
+      path = with pkgs; [ bash coreutils which ];
 
       serviceConfig = {
         Type = "simple";

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,41 @@
+{ lib, buildGoModule, makeWrapper, ffmpeg, ttyd }:
+
+buildGoModule {
+  pname = "aroz";
+  version = "unstable-2026-04-01";
+
+  # The Go source lives in src/ — the module path is imuslab.com/arozos (upstream's).
+  src = ../src;
+
+  vendorHash = "sha256-/UkMBsQuHvQjXYBvGu/kb4aL3Ae7OcMD+6n1pSnR6bg=";
+
+  # The binary name stays "arozos" to match upstream expectations.
+  # Our package name is "aroz" but the executable is "arozos".
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  ldflags = [ "-s" "-w" ];
+  tags = [ "netgo" ];
+
+  # ArozOS expects web/, system/, and subservice/ in its working directory.
+  # Install them alongside the binary so the module can symlink/copy them.
+  postInstall = ''
+    mkdir -p $out/share/aroz
+    cp -r ${../src/web} $out/share/aroz/web
+    cp -r ${../src/system} $out/share/aroz/system
+    cp -r ${../src/subservice} $out/share/aroz/subservice
+
+    # Wrap the binary so ffmpeg and ttyd are in PATH.
+    # Child processes (subservice launcher) inherit this environment.
+    wrapProgram $out/bin/arozos \
+      --prefix PATH : ${lib.makeBinPath [ ffmpeg ttyd ]}
+  '';
+
+  meta = with lib; {
+    description = "Aroz — web desktop environment (ArozOS fork)";
+    homepage = "https://github.com/spectrasecure/aroz";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    mainProgram = "arozos";
+  };
+}


### PR DESCRIPTION
## Summary

Adds a Nix flake with a `buildGoModule` package derivation and a NixOS service module for declarative deployment.

## Why native NixOS (not container)

The long-term direction for this fork is a browser-based desktop environment where NixOS handles system-level concerns (packages, services, storage) and Aroz owns the interactive desktop layer (windowing, file management, webapps, terminal). Containerizing Aroz would isolate it from the system it's meant to manage. The native approach lets subservices like the terminal operate directly on the host, and lets NixOS manage the binary, assets, and service lifecycle declaratively.

## What's included

### Package (`nix/package.nix`)
- `buildGoModule` against `src/` with verified `vendorHash` (upstream's shipped `vendor/` has a stale `modules.txt`)
- Binary wrapped with `makeWrapper` to put `ffmpeg` and `ttyd` in PATH
- Static assets (`web/`, `system/`, `subservice/`) bundled in `$out/share/aroz/`
- Build tags: `netgo`; ldflags: `-s -w`

### NixOS module (`nix/module.nix`)
- Full `services.aroz` option set: port, hostname, dataDir, user/group, TLS, maxUploadSize, extraFlags, openFirewall
- **Asset management**: immutable `web/` symlinked from Nix store; mutable `subservice/` and `system/` copied with version-gated seeding
- **Shebang patching**: NixOS has no `/bin/bash` — activation script patches shebangs to `#!/usr/bin/env bash` and bare `/bin/bash` references (e.g. ttyd spawn argument) to the Nix store bash path
- **Disabled by default**: `allow_pkg_install`, `enable_hwman`, `enable_pwman`, `allow_mdns`, `allow_ssdp`, `allow_upnp`, `disable_ip_resolver` — NixOS handles these layers
- **Systemd hardening**: `KillMode=control-group` (catches subservice children), `ProtectSystem=strict`, `ReadWritePaths` limited to dataDir
- **Service PATH**: `bash`, `coreutils`, `which` added so ArozOS can shell out to utilities it needs at runtime

### Flake (`flake.nix`)
- Exports: `packages.{system}.default`, `nixosModules.default`, `overlays.default`
- Pinned to `nixpkgs/nixos-25.11`; `nixpkgs.follows` supported for downstream consumers

### Documentation (`docs/admins/nixos.md`)
- Architecture decision rationale
- Package internals and vendorHash update workflow
- Module quick start with example flake snippets (default, existing user, Tailscale Serve, built-in TLS)
- Full options reference table
- Asset management model with complete `system/` file inventory (templates vs. runtime state)
- Systemd service details (cgroup kill, PATH, filesystem hardening, PrivateTmp)
- All deployment gotchas: `/bin/bash`, vendorHash, activation ordering, version marker, ffmpeg detection, subservice ports, sandboxed filesystem

### Other changes
- Repo remote references updated: `neonspectra/monika-aroz` → `spectrasecure/aroz`
- README updated: repo map includes `nix/`, docs table includes nixos.md, fork features list includes NixOS flake

## Deployment tested

Built and deployed on NixOS 25.11 (x86_64-linux) with EYD impermanence. Service starts cleanly, terminal subservice works (ttyd spawning Nix store bash), ffmpeg detected, web UI accessible over Tailscale Serve with automatic TLS.
